### PR TITLE
Add API handler Lambda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Node dependencies
 infrastructure/node_modules
 infrastructure/dist
+lambdas/*/node_modules
+lambdas/*/dist
 
 # CDK context
 infrastructure/cdk.out

--- a/infrastructure/lib/monitoring-stack.ts
+++ b/infrastructure/lib/monitoring-stack.ts
@@ -11,6 +11,7 @@ import * as cognito from 'aws-cdk-lib/aws-cognito';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as destinations from 'aws-cdk-lib/aws-logs-destinations';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
+import * as path from 'path';
 
 export interface MonitoringStackProps extends StackProps {
   environmentName: string; // e.g. 'prod'
@@ -48,7 +49,10 @@ export class MonitoringStack extends Stack {
     const apiHandler = new lambda.Function(this, 'ApiHandler', {
       runtime: lambda.Runtime.NODEJS_18_X,
       handler: 'index.handler',
-      code: lambda.Code.fromInline('exports.handler = async ()=>{}')
+      code: lambda.Code.fromAsset(path.join(__dirname, '../../lambdas/api-handler/dist')),
+      environment: {
+        TABLE_NAME: table.tableName
+      }
     });
 
     table.grantReadWriteData(processingFn);

--- a/lambdas/api-handler/jest.config.js
+++ b/lambdas/api-handler/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/lambdas/api-handler/package.json
+++ b/lambdas/api-handler/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "api-handler-lambda",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.470.0",
+    "@aws-sdk/lib-dynamodb": "^3.470.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.5",
+    "@types/node": "^18.17.0",
+    "@types/aws-lambda": "^8.10.119",
+    "jest": "^29.6.1",
+    "ts-jest": "^29.1.0",
+    "typescript": "^5.1.6"
+  }
+}

--- a/lambdas/api-handler/src/index.ts
+++ b/lambdas/api-handler/src/index.ts
@@ -1,0 +1,28 @@
+import { APIGatewayProxyEventV2, APIGatewayProxyResult } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
+
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+function getTenantId(event: APIGatewayProxyEventV2): string | undefined {
+  const auth: any = (event as any).requestContext.authorizer;
+  return auth?.tenantId || auth?.lambda?.tenantId || auth?.jwt?.claims?.tenantId;
+}
+
+export async function handler(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyResult> {
+  const tenantId = getTenantId(event);
+  if (!tenantId) {
+    return { statusCode: 400, body: 'Missing tenantId' };
+  }
+
+  const result = await ddb.send(new QueryCommand({
+    TableName: process.env.TABLE_NAME!,
+    KeyConditionExpression: 'tenantId = :tid',
+    ExpressionAttributeValues: { ':tid': tenantId }
+  }));
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify(result.Items ?? [])
+  };
+}

--- a/lambdas/api-handler/test/index.test.ts
+++ b/lambdas/api-handler/test/index.test.ts
@@ -1,0 +1,40 @@
+let sendMock: jest.Mock;
+
+jest.mock('@aws-sdk/lib-dynamodb', () => {
+  sendMock = jest.fn().mockResolvedValue({ Items: [{ id: 1 }] });
+  return {
+    DynamoDBDocumentClient: { from: jest.fn().mockReturnValue({ send: sendMock }) },
+    QueryCommand: jest.fn().mockImplementation((input) => ({ input }))
+  };
+});
+
+import { handler } from '../src/index';
+
+describe('handler', () => {
+  it('queries records for tenant', async () => {
+    process.env.TABLE_NAME = 'table';
+    const event = {
+      requestContext: { authorizer: { tenantId: 't1' } }
+    } as any;
+
+    const res = await handler(event);
+
+    expect(sendMock).toHaveBeenCalledWith(expect.objectContaining({
+      input: expect.objectContaining({
+        TableName: 'table',
+        KeyConditionExpression: 'tenantId = :tid',
+        ExpressionAttributeValues: { ':tid': 't1' }
+      })
+    }));
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual([{ id: 1 }]);
+  });
+
+  it('returns 400 if tenantId missing', async () => {
+    const event = { requestContext: { authorizer: {} } } as any;
+
+    const res = await handler(event);
+
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/lambdas/api-handler/tsconfig.json
+++ b/lambdas/api-handler/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "lib": ["es2020"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add cold start API handler lambda with query logic
- ignore built artifacts in lambdas
- wire new lambda code into CDK stack

## Testing
- `npm test` in `lambdas/api-handler`
- `npm test` in `lambdas/processing`


------
https://chatgpt.com/codex/tasks/task_e_68431f8b2398832789955302f5449d42