### PR TITLE
Remove ESM setting from infrastructure

### DIFF
--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -2,7 +2,6 @@
   "name": "infrastructure",
   "version": "1.0.0",
   "license": "MIT",
-  "type": "module",
   "scripts": {
     "build": "tsc",
     "cdk": "cdk",


### PR DESCRIPTION
## Summary
- remove `"type": "module"` from infrastructure package.json

## Testing
- `npx -y cdk synth` (node 18)
- `npx -y cdk synth` (node 20)
- `npx -y cdk deploy --no-exec --no-lookups --all` *(fails: Need to perform AWS calls for account 123456789012, but no credentials have been configured)*

------
https://chatgpt.com/codex/tasks/task_e_68466ce660888327b69ddad6cc74f5f6